### PR TITLE
fix: spread touchopacityprops

### DIFF
--- a/src/components/atoms/Box/index.tsx
+++ b/src/components/atoms/Box/index.tsx
@@ -46,7 +46,7 @@ const Box = ({
 
   const renderBox = {
     touchOpacity: (
-      <TouchableOpacity activeOpacity={0.8} {...{ onPress, touchOpacityProps }}>
+      <TouchableOpacity activeOpacity={0.8} {...{ onPress, ...touchOpacityProps }}>
         {viewBox}
       </TouchableOpacity>
     ),


### PR DESCRIPTION
## Issue
adding touchableopacityprops to box is not detected because the properties are nested in the touchopacityprops object#1 

## Recommended solution
spread touchOpacityProps to destructure the touchableopacityprops